### PR TITLE
Allow spaces in file paths, add bluetooth profile 110E (AV_RemoteControl)

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,8 +28,9 @@ Same same on connect.
 Check if your headphones offer more BT services than:
 - Hands-Free Profile (111E)
 - A2DP AudioSink (110B)
+- A/V_RemoteControl (110E) (media control keys)
 
-If so, add them to `connect.bat` and `disconnect.bat` files. 
+If so, add them to `connect.bat` and `disconnect.bat` files (and remove any that your headphones don't offer).
 
 The list of services can be found [here](https://www.bluetooth.com/specifications/assigned-numbers/service-discovery/).
 

--- a/connect.bat
+++ b/connect.bat
@@ -1,3 +1,3 @@
-set /p mac=<%~dp0mac.txt
+set /p mac=<"%~dp0mac.txt"
 btcom -b %mac% -c -s110b
 btcom -b %mac% -c -s111e

--- a/connect.bat
+++ b/connect.bat
@@ -1,3 +1,4 @@
 set /p mac=<"%~dp0mac.txt"
-btcom -b %mac% -c -s110b
 btcom -b %mac% -c -s111e
+btcom -b %mac% -c -s110e
+btcom -b %mac% -c -s110b

--- a/connectForce.bat
+++ b/connectForce.bat
@@ -1,5 +1,7 @@
-set /p mac=<%~dp0mac.txt
-btcom -b %mac% -r -s110b
+set /p mac=<"%~dp0mac.txt"
 btcom -b %mac% -r -s111e
-btcom -b %mac% -c -s110b
+btcom -b %mac% -r -s110e
+btcom -b %mac% -r -s110b
 btcom -b %mac% -c -s111e
+btcom -b %mac% -c -s110e
+btcom -b %mac% -c -s110b

--- a/disconnect.bat
+++ b/disconnect.bat
@@ -1,3 +1,4 @@
-set /p mac=<%~dp0mac.txt
-btcom -b %mac% -r -s110b
+set /p mac=<"%~dp0mac.txt"
 btcom -b %mac% -r -s111e
+btcom -b %mac% -r -s110e
+btcom -b %mac% -r -s110b

--- a/disconnectForce.bat
+++ b/disconnectForce.bat
@@ -1,5 +1,7 @@
-set /p mac=<%~dp0mac.txt
-btcom -b %mac% -c -s110b
+set /p mac=<"%~dp0mac.txt"
 btcom -b %mac% -c -s111e
-btcom -b %mac% -r -s110b
+btcom -b %mac% -c -s110e
+btcom -b %mac% -c -s110b
 btcom -b %mac% -r -s111e
+btcom -b %mac% -r -s110e
+btcom -b %mac% -r -s110b


### PR DESCRIPTION
I've added quotation marks around %~dp0mac.txt to allow paths with spaces in them. Also I've added the bluetooth profile 110E to all four *.bat files as most headphones should support that profile. (I've added a note to readme to remove unsupported profiles)

If I get around to it, I might add some kind of "config" file in the future (just a list of services to enable/disable; read line by line, if I feel fancy I'll parse for some comment character).